### PR TITLE
fix: 429 エラーの処理を修正

### DIFF
--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -2026,23 +2026,38 @@ namespace Fitbit.Api.Portable
         {
             if (!response.IsSuccessStatusCode)
             {
-                // assumption is error response from fitbit in the 4xx range  
-                var errors = new JsonDotNetSerializer().ParseErrors(await response.Content.ReadAsStringAsync());
+                List<ApiError> errors = [];
 
                 // rate limit hit
-                if (429 == (int)response.StatusCode)
+                if (response.StatusCode == HttpStatusCode.TooManyRequests)
                 {
-                    // not sure if we can use 'RetryConditionHeaderValue' directly as documentation is minimal for the header
-                    var retryAfterHeader = response.Headers.GetValues("Retry-After").FirstOrDefault();
+                    int retryAfter = 3600; // default value (1 hour)
+
+                    // see https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Rate-Limits
+                    var retryAfterHeader = response.Headers.GetValues("Fitbit-Rate-Limit-Reset").FirstOrDefault();
                     if (retryAfterHeader != null)
                     {
-                        int retryAfter;
-                        if (int.TryParse(retryAfterHeader, out retryAfter))
+                        if (!int.TryParse(retryAfterHeader, out retryAfter))
                         {
-                            throw new FitbitRateLimitException(retryAfter, errors);
+                            errors.Add(new ApiError
+                            {
+                                Message = $"Fitbit-Rate-Limit-Reset has invalid value: {retryAfterHeader}",
+                            });
                         }
                     }
+                    else
+                    {
+                        errors.Add(new ApiError
+                        {
+                            Message = $"Fitbit-Rate-Limit-Reset header not found",
+                        });
+                    }
+
+                    throw new FitbitRateLimitException(retryAfter, errors);
                 }
+
+                // assumption is error response from fitbit in the 4xx range
+                errors = new JsonDotNetSerializer().ParseErrors(await response.Content.ReadAsStringAsync());
 
                 // request exception parsing
                 switch (response.StatusCode)


### PR DESCRIPTION
~動作確認中です。動作確認が終わったら DRAFT を外します。~

## 内容

429 エラーの処理がレスポンス内容に合っておらず、`NullReferenceExceptin` が発生していたので修正しました。

## 詳細

### Body の操作に誤りがある

ライブラリは以下のような Body を期待しています。

```json
{
  "errors": [
    {
      "code": 429,
      "message": "Resource has been exhausted (e.g. check quota).",
      "status": "RESOURCE_EXHAUSTED"
    }
  ]
}
```

実際の Body は以下のようになっており、JSON パース時に `NullReferenceException` が発生していました。

```json
{
  "error": {
    "code": 429,
    "message": "Resource has been exhausted (e.g. check quota).",
    "status": "RESOURCE_EXHAUSTED"
  }
}
```

エラー 429 には Body の中に重要な値はないため、Body を JSON パースしないように修正しました。

### Retry-After の処理に誤りがある

ライブラリは HTTP 標準の [Retry-After ヘッダー](https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Headers/Retry-After) を期待していますが、Fitbit Web API では同等のヘッダーとして [Fitbit-Rate-Limit-Reset ヘッダー](https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Rate-Limits) が使われています。
こちらを参照するように変えました。